### PR TITLE
ELFVersion.jl additions

### DIFF
--- a/src/ELF/ELFVersion.jl
+++ b/src/ELF/ELFVersion.jl
@@ -40,6 +40,7 @@ end
 function ELFVersionData(oh::H) where {H <: ELFHandle}
     s = findfirst(Sections(oh), ".gnu.version_d")
     strtab = StrTab(findfirst(Sections(oh), ".dynstr"))
+    (isnothing(s) || isnothing(strtab)) && return ELFVersionEntry[]
 
     # Queue oh up to the beginning of this section
     seek(oh, section_offset(s))

--- a/src/ELF/ELFVersion.jl
+++ b/src/ELF/ELFVersion.jl
@@ -24,6 +24,14 @@ end
     vn_next::UInt32
 end
 
+@io struct ELFVernAux{H <: ELFHandle}
+    vna_hash::UInt32
+    vna_flags::UInt16
+    vna_other::UInt16
+    vna_name::UInt32
+    vna_next::UInt32
+end
+
 struct ELFVersionEntry{H <: ELFHandle}
     ver_def::ELFVerDef{H}
     names::Vector{String}
@@ -62,4 +70,20 @@ function ELFVersionData(oh::H) where {H <: ELFHandle}
     end
     
     return version_defs
+end
+
+"""
+Hash function used to create vd_hash from vda_name, or vna_hash from vna_name
+"""
+function ELFHash(v::Vector{UInt8})
+    h = UInt32(0)
+    for b in v
+        h = (h << 4) + b
+        hi = h & 0xf0000000
+        if (hi != 0)
+            h ⊻= (hi >> 24)
+        end
+        h &= ~hi
+    end
+    return h
 end


### PR DESCRIPTION
I used ObjectFile to write a script to patch versions in ELF files and decided some parts of it might belong here.

- Of the four version definition/requirement structs (verdef, verdaux, verneed, vernaux), we're missing the fourth, so add it
- Fix `ELFVersionData` not working if it doesn't find a `.gnu.version_d` section:
  ```
  julia> ELFVersionData(oh)
  ERROR: MethodError: no method matching section_offset(::Nothing)
  The function `section_offset` exists, but no method is defined for this combination of argument types.
  ```
- Add `ELFVersionNeededData`, a similar function for version requirements (`.gnu.version_r`)
- Add elf hash function used in version definitions and requirements (see https://en.wikipedia.org/wiki/PJW_hash_function)